### PR TITLE
Develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparql-result-converter",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Little utility function to that converts the table-like result of a SPARQL query into a JSON tree with a user-defined structure",
   "scripts": {
     "clean": "rimraf dist && rimraf *.tsbuildinfo",

--- a/src/SparqlResultConverter.ts
+++ b/src/SparqlResultConverter.ts
@@ -111,6 +111,8 @@ export class SparqlResultConverter {
 				// if there is nothing to group and the inputArry is not empty -> Simple return the inputArray as output
 				if(!inputArray.every(elem => isEmpty(elem)) && keepUngroupedContents) {
 					outputObject[mappingDefinition.rootName] = [...inputArray];
+				} else {
+					outputObject[mappingDefinition.rootName] = [];
 				}
 			}
 

--- a/tests/multiplePropertyTests/expectedResults.ts
+++ b/tests/multiplePropertyTests/expectedResults.ts
@@ -6,7 +6,8 @@ export const expectedTwoLayerResult = {
 			{
 				petName: 'Rex',
 			}
-		]
+		],
+		cats: []
 	},
 	{
 		ownerName: 'John',

--- a/tests/onePropertyTests/expectedResults.ts
+++ b/tests/onePropertyTests/expectedResults.ts
@@ -268,9 +268,11 @@ export const expectedTwoLayerResultWithCollectedProperty = {
 						{
 							petName: 'Huey',
 						},
-						{ petName: 'Dewey',
+						{
+							petName: 'Dewey',
 						},
-						{ petName: 'Louie',
+						{
+							petName: 'Louie',
 						},
 					]
 				}

--- a/tests/skillTests/expectedResults.ts
+++ b/tests/skillTests/expectedResults.ts
@@ -2,12 +2,12 @@
 export const skillResult = {
 	skills : [
 		{
-			skillIri: 'https://siemens.de/skills#OpcUaSkill',
-			stateMachine: 'https://siemens.de/skills#OpcUaSkill_StateMachine',
+			skillIri: 'https://www.hsu-hh.de/skills#OpcUaSkill',
+			stateMachine: 'https://www.hsu-hh.de/skills#OpcUaSkill_StateMachine',
 			currentStateTypeIri: 'http://www.hsu-ifa.de/ontologies/ISA-TR88#Idle',
 			skillParameters: [
 				{
-					parameterIri: 'https://siemens.de/skills#OpcUaSkill_a',
+					parameterIri: 'https://www.hsu-hh.de/skills#OpcUaSkill_a',
 					parameterName: 'a',
 					parameterType: 'Integer',
 					parameterRequired: 'true',
@@ -15,19 +15,21 @@ export const skillResult = {
 					parameterOptionValues: [ { value: '2' }, { value: '3' }, { value: '4' } ]
 				},
 				{
-					parameterIri: 'https://siemens.de/skills#OpcUaSkill_b',
+					parameterIri: 'https://www.hsu-hh.de/skills#OpcUaSkill_b',
 					parameterName: 'b',
 					parameterType: 'Integer',
 					parameterRequired: 'true',
 					parameterDefault: '0',
+					parameterOptionValues: []
 				}
 			],
 			skillOutputs: [
 				{
-					outputIri: 'https://siemens.de/skills#OpcUaSkill_result',
+					outputIri: 'https://www.hsu-hh.de/skills#OpcUaSkill_result',
 					outputName: 'result',
 					outputType: 'Integer',
-					outputRequired: 'false'
+					outputRequired: 'false',
+					outputOptionValues: []
 				}
 			]
 		}

--- a/tests/skillTests/test-data.ts
+++ b/tests/skillTests/test-data.ts
@@ -54,15 +54,15 @@ export const testData = {
 				},
 				"outputIri": {
 					"type": "uri",
-					"value": "https://siemens.de/skills#OpcUaSkill_result"
+					"value": "https://www.hsu-hh.de/skills#OpcUaSkill_result"
 				},
 				"stateMachine": {
 					"type": "uri",
-					"value": "https://siemens.de/skills#OpcUaSkill_StateMachine"
+					"value": "https://www.hsu-hh.de/skills#OpcUaSkill_StateMachine"
 				},
 				"skill": {
 					"type": "uri",
-					"value": "https://siemens.de/skills#OpcUaSkill"
+					"value": "https://www.hsu-hh.de/skills#OpcUaSkill"
 				},
 				"outputRequired": {
 					"type": "literal",
@@ -70,7 +70,7 @@ export const testData = {
 				},
 				"parameterIri": {
 					"type": "uri",
-					"value": "https://siemens.de/skills#OpcUaSkill_a"
+					"value": "https://www.hsu-hh.de/skills#OpcUaSkill_a"
 				},
 				"parameterRequired": {
 					"type": "literal",
@@ -108,15 +108,15 @@ export const testData = {
 				},
 				"outputIri": {
 					"type": "uri",
-					"value": "https://siemens.de/skills#OpcUaSkill_result"
+					"value": "https://www.hsu-hh.de/skills#OpcUaSkill_result"
 				},
 				"stateMachine": {
 					"type": "uri",
-					"value": "https://siemens.de/skills#OpcUaSkill_StateMachine"
+					"value": "https://www.hsu-hh.de/skills#OpcUaSkill_StateMachine"
 				},
 				"skill": {
 					"type": "uri",
-					"value": "https://siemens.de/skills#OpcUaSkill"
+					"value": "https://www.hsu-hh.de/skills#OpcUaSkill"
 				},
 				"outputRequired": {
 					"type": "literal",
@@ -124,7 +124,7 @@ export const testData = {
 				},
 				"parameterIri": {
 					"type": "uri",
-					"value": "https://siemens.de/skills#OpcUaSkill_a"
+					"value": "https://www.hsu-hh.de/skills#OpcUaSkill_a"
 				},
 				"parameterRequired": {
 					"type": "literal",
@@ -162,15 +162,15 @@ export const testData = {
 				},
 				"outputIri": {
 					"type": "uri",
-					"value": "https://siemens.de/skills#OpcUaSkill_result"
+					"value": "https://www.hsu-hh.de/skills#OpcUaSkill_result"
 				},
 				"stateMachine": {
 					"type": "uri",
-					"value": "https://siemens.de/skills#OpcUaSkill_StateMachine"
+					"value": "https://www.hsu-hh.de/skills#OpcUaSkill_StateMachine"
 				},
 				"skill": {
 					"type": "uri",
-					"value": "https://siemens.de/skills#OpcUaSkill"
+					"value": "https://www.hsu-hh.de/skills#OpcUaSkill"
 				},
 				"outputRequired": {
 					"type": "literal",
@@ -178,7 +178,7 @@ export const testData = {
 				},
 				"parameterIri": {
 					"type": "uri",
-					"value": "https://siemens.de/skills#OpcUaSkill_a"
+					"value": "https://www.hsu-hh.de/skills#OpcUaSkill_a"
 				},
 				"parameterRequired": {
 					"type": "literal",
@@ -192,11 +192,11 @@ export const testData = {
 				},
 				"outputIri": {
 					"type": "uri",
-					"value": "https://siemens.de/skills#OpcUaSkill_result"
+					"value": "https://www.hsu-hh.de/skills#OpcUaSkill_result"
 				},
 				"stateMachine": {
 					"type": "uri",
-					"value": "https://siemens.de/skills#OpcUaSkill_StateMachine"
+					"value": "https://www.hsu-hh.de/skills#OpcUaSkill_StateMachine"
 				},
 				"outputName": {
 					"type": "literal",
@@ -208,7 +208,7 @@ export const testData = {
 				},
 				"skill": {
 					"type": "uri",
-					"value": "https://siemens.de/skills#OpcUaSkill"
+					"value": "https://www.hsu-hh.de/skills#OpcUaSkill"
 				},
 				"outputRequired": {
 					"type": "literal",
@@ -216,7 +216,7 @@ export const testData = {
 				},
 				"parameterIri": {
 					"type": "uri",
-					"value": "https://siemens.de/skills#OpcUaSkill_b"
+					"value": "https://www.hsu-hh.de/skills#OpcUaSkill_b"
 				},
 				"outputType": {
 					"type": "literal",


### PR DESCRIPTION
Returning empty array instead of undefined so that applications using this lib can depend on all elements inside  a mapping definition and don't have to check for undefined.

E. g. when looping over a result array, there previously was a need to check for undefined. Now, one can just loop as the array will always exist and will just be empty in case no grouping was done